### PR TITLE
Use secure URI in Vcs control header.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cupt (2.10.3) UNRELEASED; urgency=medium
+
+  * Use secure URI in Vcs control header.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Sat, 15 Sep 2018 23:41:11 +0100
+
 cupt (2.10.2) unstable; urgency=medium
 
   * lib:

--- a/debian/control
+++ b/debian/control
@@ -29,7 +29,7 @@ Build-Depends:
 Maintainer: Eugene V. Lyubimkin <jackyf@debian.org>
 Homepage: http://wiki.debian.org/Cupt
 Standards-Version: 4.1.3
-Vcs-Git: git://github.com/jackyf/cupt.git
+Vcs-Git: https://github.com/jackyf/cupt.git
 Vcs-Browser: https://github.com/jackyf/cupt/tree/master
 
 Package: cupt-dbg


### PR DESCRIPTION
Use secure URI in Vcs control header.

Fixes lintian: vcs-field-uses-insecure-uri
See https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html for more details.
