### PR TITLE
Use secure URI in Homepage field.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cupt (2.10.3) UNRELEASED; urgency=medium
+
+  * Use secure URI in Homepage field.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Sat, 15 Sep 2018 23:41:50 +0100
+
 cupt (2.10.2) unstable; urgency=medium
 
   * lib:

--- a/debian/control
+++ b/debian/control
@@ -27,7 +27,7 @@ Build-Depends:
   libexpect-simple-perl,
   locales-all
 Maintainer: Eugene V. Lyubimkin <jackyf@debian.org>
-Homepage: http://wiki.debian.org/Cupt
+Homepage: https://wiki.debian.org/Cupt
 Standards-Version: 4.1.3
 Vcs-Git: git://github.com/jackyf/cupt.git
 Vcs-Browser: https://github.com/jackyf/cupt/tree/master


### PR DESCRIPTION
Use secure URI in Homepage field.

Fixes lintian: homepage-field-uses-insecure-uri
See https://lintian.debian.org/tags/homepage-field-uses-insecure-uri.html for more details.
